### PR TITLE
Enhancement: Allow Custom Phone Number for Bot Responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.wwebjs_cache
 /.wwebjs_auth
 /package-lock.json
+/chats_history

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 /.wwebjs_cache
 /.wwebjs_auth
 /package-lock.json
+
 /chats_history
+/.audio_cache

--- a/bot.js
+++ b/bot.js
@@ -25,11 +25,13 @@ client.on('qr', qr => {
 
 client.on('ready', () => {
     console.log(colors.bold.green('[+] Client is ready!'));
+    
+    if(process.env.PHONE_NUMBER_TO_CONTACT)
+        console.log(colors.bold.blue("The bot will reply only for this number if defined correctly in .env:\n" +process.env.PHONE_NUMBER_TO_CONTACT))
 });
 
 // Listen for incoming messages from users
 client.on('message', async message => {
-    console.log(process.env.PHONE_NUMBER_TO_CONTACT)
     if (process.env.PHONE_NUMBER_TO_CONTACT && message.from !== `${process.env.PHONE_NUMBER_TO_CONTACT}@c.us`) 
         return;
 

--- a/bot.js
+++ b/bot.js
@@ -1,5 +1,5 @@
 const qrcode = require('qrcode-terminal');
-const {Client, LocalAuth, MessageMedia} = require('whatsapp-web.js');
+const { Client, LocalAuth, MessageMedia } = require('whatsapp-web.js');
 
 const fs = require('fs');
 const child_process = require('child_process');
@@ -20,7 +20,7 @@ const client = new Client({
 
 // Display the QR code for user authentication
 client.on('qr', qr => {
-    qrcode.generate(qr, {small: true});
+    qrcode.generate(qr, { small: true });
 });
 
 client.on('ready', () => {
@@ -29,85 +29,87 @@ client.on('ready', () => {
 
 // Listen for incoming messages from users
 client.on('message', async message => {
+    if (message.from === `${process.env.PHONE_NUMBER_TO_CONTACT}@c.us`) {
 
-    const chat = await message.getChat();
-    let roleActionReq = message.body.includes("!act");
-    let imageReq = message.body.includes("!generate");
-    let transcribeReq = message.body.includes("!transcribe");
-    const chatID = chat.id._serialized;
-    
-    if(transcribeReq){
-        if (!message.hasQuotedMsg) {
-            await chat.sendMessage("You should quote a audio/video message!");
-            return;
-        }
-        
-        const quote = await message.getQuotedMessage();
-        if (!quote.hasMedia || !(quote.type == "audio" || quote.type == "voice" || quote.type == "ptt" || quote.type == "video")) {
-            await message.reply("That message doesn't contain any audio!");
-            return;
-        }
-        chat.sendStateTyping();
+        const chat = await message.getChat();
+        let roleActionReq = message.body.includes("!act");
+        let imageReq = message.body.includes("!generate");
+        let transcribeReq = message.body.includes("!transcribe");
+        const chatID = chat.id._serialized;
 
-        const filename = message.id.id;
-        const downloadedMedia = await quote.downloadMedia();
-        let buffer = Buffer.from(downloadedMedia.data, 'base64');
-        fs.writeFileSync(`./.audio_cache/${filename}.ogg`, buffer);
-        
-        //-hide_banner -loglevel error flags are only for logging purposes.
-        child_process.execSync(`ffmpeg -hide_banner -loglevel error -i .audio_cache/${filename}.ogg -acodec libmp3lame .audio_cache/${filename}.mp3`);
-        
-        let transcription = await GPT.transcribeAudio(`.audio_cache/${filename}.mp3`);
-        await chat.sendMessage(transcription);
-
-        unlink(`.audio_cache/${filename}.mp3`, (err) =>{
-            if (err) console.error(err);
-        })
-        unlink(`.audio_cache/${filename}.ogg`, (err) =>{
-            if (err) console.error(err);
-        })
-        return;
-    }
-    if(imageReq){
-        const formatted_input = chat_functionalities.validateAndExtractImgCommand(message.body);
-        if(formatted_input.valid){
-            let images = await GPT.generateImage(formatted_input.prompt,formatted_input.number);
-            for (const image of images) {
-                const imageUrlMedia = await MessageMedia.fromUrl(image.url);
-                await chat.sendMessage(imageUrlMedia);
+        if (transcribeReq) {
+            if (!message.hasQuotedMsg) {
+                await chat.sendMessage("You should quote a audio/video message!");
+                return;
             }
+
+            const quote = await message.getQuotedMessage();
+            if (!quote.hasMedia || !(quote.type == "audio" || quote.type == "voice" || quote.type == "ptt" || quote.type == "video")) {
+                await message.reply("That message doesn't contain any audio!");
+                return;
+            }
+            chat.sendStateTyping();
+
+            const filename = message.id.id;
+            const downloadedMedia = await quote.downloadMedia();
+            let buffer = Buffer.from(downloadedMedia.data, 'base64');
+            fs.writeFileSync(`./.audio_cache/${filename}.ogg`, buffer);
+
+            //-hide_banner -loglevel error flags are only for logging purposes.
+            child_process.execSync(`ffmpeg -hide_banner -loglevel error -i .audio_cache/${filename}.ogg -acodec libmp3lame .audio_cache/${filename}.mp3`);
+
+            let transcription = await GPT.transcribeAudio(`.audio_cache/${filename}.mp3`);
+            await chat.sendMessage(transcription);
+
+            unlink(`.audio_cache/${filename}.mp3`, (err) => {
+                if (err) console.error(err);
+            })
+            unlink(`.audio_cache/${filename}.ogg`, (err) => {
+                if (err) console.error(err);
+            })
+            return;
         }
-        else
-            await chat.sendMessage("invalid command\n!generate [number] [prompt]")
-        return;
-    }
-    await chat.sendStateTyping();
-    // Create or retrieve the chat history file
-    let filePath = 'chats_history/'+chat_functionalities.removePattern(chatID) + '.json';
+        if (imageReq) {
+            const formatted_input = chat_functionalities.validateAndExtractImgCommand(message.body);
+            if (formatted_input.valid) {
+                let images = await GPT.generateImage(formatted_input.prompt, formatted_input.number);
+                for (const image of images) {
+                    const imageUrlMedia = await MessageMedia.fromUrl(image.url);
+                    await chat.sendMessage(imageUrlMedia);
+                }
+            }
+            else
+                await chat.sendMessage("invalid command\n!generate [number] [prompt]")
+            return;
+        }
+        await chat.sendStateTyping();
+        // Create or retrieve the chat history file
+        let filePath = 'chats_history/' + chat_functionalities.removePattern(chatID) + '.json';
 
-    if(roleActionReq){
-        // Extract the content after "!act" and log it as a system action
-        let contentRegex = chat_functionalities.extractTextAfterAct(message.body);
-        chat_functionalities.createChatHistoryOrRetrieve(filePath, {role: 'system', content: contentRegex});
-        GPT.messages.push({ role: 'system', content: contentRegex });
-        await message.reply("trying to act like mentioned");
-    }
-    else{
-        // Log user messages in chat history
-        chat_functionalities.createChatHistoryOrRetrieve(filePath, {role: 'user', content: message.body});
-        GPT.messages.push({ role: 'user', content: message.body });
-    }
+        if (roleActionReq) {
+            // Extract the content after "!act" and log it as a system action
+            let contentRegex = chat_functionalities.extractTextAfterAct(message.body);
+            chat_functionalities.createChatHistoryOrRetrieve(filePath, { role: 'system', content: contentRegex });
+            GPT.messages.push({ role: 'system', content: contentRegex });
+            await message.reply("trying to act like mentioned");
+        }
+        else {
+            // Log user messages in chat history
+            chat_functionalities.createChatHistoryOrRetrieve(filePath, { role: 'user', content: message.body });
+            GPT.messages.push({ role: 'user', content: message.body });
+        }
 
-    // Generate a response
-    let answer = await GPT.askGPT();
+        // Generate a response
+        let answer = await GPT.askGPT();
 
-    if(!roleActionReq){
-        await chat.sendMessage(answer);
+        if (!roleActionReq) {
+            await chat.sendMessage(answer);
+        }
+
+        // Update the chat history for assistant ROLE
+        if (ASSISTANT_LOGS)
+            GPT.chatHistory = chat_functionalities.createChatHistoryOrRetrieve(filePath, { role: 'asistant', content: answer });
     }
-    
-    // Update the chat history for assistant ROLE
-    if(ASSISTANT_LOGS)
-        GPT.chatHistory = chat_functionalities.createChatHistoryOrRetrieve(filePath, { role: 'asistant', content: answer });
 });
 
 // Initialize the WhatsApp client

--- a/bot.js
+++ b/bot.js
@@ -29,7 +29,9 @@ client.on('ready', () => {
 
 // Listen for incoming messages from users
 client.on('message', async message => {
-    if (message.from === `${process.env.PHONE_NUMBER_TO_CONTACT}@c.us`) {
+    console.log(process.env.PHONE_NUMBER_TO_CONTACT)
+    if (process.env.PHONE_NUMBER_TO_CONTACT && message.from !== `${process.env.PHONE_NUMBER_TO_CONTACT}@c.us`) 
+        return;
 
         const chat = await message.getChat();
         let roleActionReq = message.body.includes("!act");
@@ -109,7 +111,6 @@ client.on('message', async message => {
         // Update the chat history for assistant ROLE
         if (ASSISTANT_LOGS)
             GPT.chatHistory = chat_functionalities.createChatHistoryOrRetrieve(filePath, { role: 'asistant', content: answer });
-    }
 });
 
 // Initialize the WhatsApp client

--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,11 @@ Create the directory using the following command:
     ```bash
     node bot.js
     ```
-8. **Start Chatting:** Once the bot is running and authenticated, you can start chatting with it on WhatsApp!
+8. **(OPTINAL) For testing purposes**:
+    ```
+    PHONE_NUMBER_TO_CONTACT = your_number 
+    ```
+9. **Start Chatting:** Once the bot is running and authenticated, you can start chatting with it on WhatsApp!
 
 
 ## Using the Chatbot


### PR DESCRIPTION
**What's Changed:**
Now you can define a custom phone number to which the bot will respond.

**How to Set It Up:**
In the `.env` file, add a new constant named `PHONE_NUMBER_TO_CONTACT` and assign it the specific phone number you want the bot to respond to.

```bash
PHONE_NUMBER_TO_CONTACT=your-desired-phone-number
```

**Result:**
After setting the `PHONE_NUMBER_TO_CONTACT`, the bot will respond only when it receives messages from this specific phone number. This feature enhances the bot's flexibility and allows for more customization in its behavior.

